### PR TITLE
Add config option to enable/disable online player reporting

### DIFF
--- a/PayNow.cs
+++ b/PayNow.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json;
@@ -10,7 +10,7 @@ using System.Text;
 
 namespace Oxide.Plugins
 {
-    [Info("PayNow", "PayNow Services Inc", "0.0.13")]
+    [Info("PayNow", "PayNow Services Inc", "0.0.14")]
     [Description("Official plugin for the PayNow.gg store integration.")]
     internal class PayNow : CovalencePlugin
     {
@@ -167,8 +167,13 @@ namespace Oxide.Plugins
 
             try
             {
+                // Don't check the player list if disabled for servers that don't care about this functionality
+                // Adds in an empty list to maintain compatibility for the API
+                string payload = _config.EnableOnlinePlayerReporting 
+                ? BuildOnlinePlayersJson() 
+                : "{\"steam_ids\":[]}";
                 // Make the API call
-                webrequest.Enqueue(COMMAND_QUEUE_URL, BuildOnlinePlayersJson(), HandlePendingCommands, this, RequestMethod.POST, _headers, _config.ApiCheckIntervalSeconds);
+                webrequest.Enqueue(COMMAND_QUEUE_URL, payload, HandlePendingCommands, this, RequestMethod.POST, _headers, _config.ApiCheckIntervalSeconds);
             }
             catch (Exception ex)
             {
@@ -304,7 +309,7 @@ namespace Oxide.Plugins
             [JsonProperty("steam_id")] public string SteamId;
 
             [JsonProperty("command")] public string Command;
-
+            // Allow servers to disable online player checks
             [JsonProperty("online_only")] public bool OnlineOnly;
 
             [JsonProperty("queued_at")] public string QueuedAt;
@@ -364,6 +369,9 @@ namespace Oxide.Plugins
 
             [JsonProperty("Log command executions")]
             public bool LogCommandExecutions = true;
+
+            [JsonProperty("Enable online player reporting")]
+            public bool EnableOnlinePlayerReporting = true;
 
             // Backwards compatibility
             [JsonProperty("ApiToken")]


### PR DESCRIPTION
Key changes:

Added "EnableOnlinePlayerReporting" to the PluginConfig class, defaulting to true to maintain existing behavior.

Modified the GetPendingCommands() method to conditionally build the request payload:

When "EnableOnlinePlayerReporting" is true, it includes the online player Steam IDs by calling BuildOnlinePlayersJson() as before.
When "EnableOnlinePlayerReporting" is false, it sends an empty list of Steam IDs in the payload: "{\"steam_ids\":[]}".
Added comments to explain the new conditional logic and config option.

This change provides flexibility for server owners who may not want to send player information with each API request. By disabling the feature, the plugin will still check for pending commands from PayNow, but without including the online player data in the request.

Backward compatibility is maintained as the new config option defaults to true, preserving the existing behavior for servers that rely on player reporting.